### PR TITLE
Support WASM bundling & inlining

### DIFF
--- a/make.cjs
+++ b/make.cjs
@@ -14,3 +14,18 @@ const esbuild = require('esbuild');
 		plugins: []
 	});
 })();
+
+(async () => {
+	await esbuild.build({
+		entryPoints: ['src/trealla.ts'],
+		bundle: true,
+		outdir: 'dist-unbundled',
+		format: 'esm',
+		loader: {'.wasm': 'copy'},
+		target: ['es2022'],
+		minify: false,
+		keepNames: true,
+		sourcemap: false,
+		plugins: []
+	});
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "trealla",
-	"version": "0.24.9",
+	"name": "trealla-multibundle",
+	"version": "0.27.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "trealla",
-			"version": "0.24.9",
+			"name": "trealla-multibundle",
+			"version": "0.27.7",
 			"license": "MIT",
 			"dependencies": {
 				"browser_wasi_shim_gaiden": "^0.3.6"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"clean": "rm -f libtpl.wasm trealla.js trealla.js.map index.d.ts index.d.ts.map dist/*",
 		"update": "git submodule update --init --recursive && cd trealla && git fetch && git pull origin main",
 		"compile": "cd trealla && make clean && make -j8 libtpl-js && mv libtpl-js.wasm ../libtpl.wasm",
-		"build": "node make.cjs && npx tsc",
+		"build": "node make.cjs && npx tsc && npx tsc -p tsconfig.unbundled.json",
 		"watch": "nodemon --exec 'npm run build && cp dist/trealla.js example/browser/' --ignore 'example' --watch 'src' --watch 'libtpl.wasm' --ext ts,wasm",
 		"test": "npm run build && node test.js"
 	},

--- a/package.json
+++ b/package.json
@@ -1,18 +1,31 @@
 {
-	"name": "trealla",
-	"version": "0.27.2",
+	"name": "trealla-multibundle",
+	"version": "0.27.7",
 	"description": "Trealla Prolog bindings for JS",
 	"main": "dist/trealla.js",
 	"type": "module",
 	"types": "dist/index.d.ts",
 	"files": [
 		"ATTRIBUTION",
-		"dist/index.d.ts"
+		"dist/index.d.ts",
+		"dist-unbundled/**.d.ts",
+		"dist-unbundled/**.js",
+		"dist-unbundled/**.wasm"
 	],
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"default": "./dist/trealla.js"
+		},
+		"./unbundled": {
+			"types": "./dist-unbundled/index.d.ts",
+			"default": "./dist-unbundled/trealla.js"
+		}
+	},
+	"typesVersions": {
+		"*": {
+			".": "./dist/index.d.ts",
+			"./unbundled": "./dist-unbundled/index.d.ts"
 		}
 	},
 	"repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,5 +100,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["example", "node_modules", "dist"]
+  "exclude": ["example", "node_modules", "dist", "dist-unbundled"]
 }

--- a/tsconfig.unbundled.json
+++ b/tsconfig.unbundled.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outFile": "./dist-unbundled/index.d.ts",
+    "outDir": "./dist-unbundled", 
+  }
+}


### PR DESCRIPTION
Attempt to address #45 , showcase, not for merge

---

This approach adds 2 builds to the package:
1. The former one that inlines .wasm binary into the dist JS file
2. New one that copies the .wasm file to dist directory and keeps the import

Then the package defines different entrypoints.

This means the API (usage) of the package stays the same, the user will have to choose only at import time (to distinguish between the 2 bundling options their platform supports).

```ts
import { load, Prolog } from "trealla"; // for most runtimes
// or
import { load, Prolog } from "trealla/unbundled"; // for CF Workers and other envs that want to import .wasm file at runtime

// same code usage
```

---

NPM forked package (issues with types due to different module name):
- https://www.npmjs.com/package/trealla-multibundle

Demo on Vercel (serverless Node.js function)
- https://github.com/kysely/trealla-demo-next/blob/main/src/app/api/query/node/route.ts#L2
- https://trealla-demo-next.vercel.app/api/query/node

Demo on Cloudflare Workers (edge V8 isolate)
- https://github.com/kysely/trealla-demo-cf/blob/main/src/index.ts#L15
- https://trealla-demo-cf.kysely.workers.dev